### PR TITLE
goThrough: Skip our own images

### DIFF
--- a/insta.go
+++ b/insta.go
@@ -170,6 +170,11 @@ func goThrough(images response.TagFeedsResponse) {
 			break
 		}
 
+		// Skip our own images
+		if image.User.Username == viper.GetString("user.instagram.username") {
+			continue
+		}
+
 		// Getting the user info
 		// Instagram will return a 500 sometimes, so we will retry 10 times.
 		// Check retry() for more info.


### PR DESCRIPTION
The main aim is to get attention from other Instagram users. Furthermore
it looks stupid when the bot comments our posts.