### PR TITLE
Fix: Don't iterate forever over image list for a single tag

### DIFF
--- a/dist/config.json
+++ b/dist/config.json
@@ -13,7 +13,6 @@
         }
     },
     "limits" : {                            
-	"maxRetry" : 2,
         "like" : {                          
             "min" : 0,                      
             "max" : 10000                   

--- a/dist/config.json
+++ b/dist/config.json
@@ -13,6 +13,7 @@
         }
     },
     "limits" : {                            
+	"maxRetry" : 2,
         "like" : {                          
             "min" : 0,                      
             "max" : 10000                   

--- a/insta.go
+++ b/insta.go
@@ -161,7 +161,7 @@ func browse() {
 
 		goThrough(images)
 
-		if i > viper.GetInt("limits.maxRetry") {
+		if viper.IsSet("limits.maxRetry") && i > viper.GetInt("limits.maxRetry") {
 			log.Println("Currently not enough images for this tag to achieve goals")
 			break
 		}


### PR DESCRIPTION
...if there aren't enough images to complete all like, comment, and follow
jobs. The bot will now try to get some fresh images for tags. Furthermore,
with the new config parameter "limits.maxRetry" you are able to configure
how often the bot will try to get new images for the current tag until the
next tag will be checked. Tag limits (e.g. number of likes) in config.json
will be handled on a 'best effort' basis.