### PR TITLE
Check environment for configuration

### DIFF
--- a/util.go
+++ b/util.go
@@ -108,6 +108,12 @@ func getConfig() {
 		log.Fatalf("Error reading config file, %s", err)
 	}
 
+	// Check enviroment
+	viper.SetEnvPrefix("instabot")
+	replacer := strings.NewReplacer(".", "_")
+	viper.SetEnvKeyReplacer(replacer)
+	viper.AutomaticEnv()
+
 	// Confirms which config file is used
 	log.Printf("Using config: %s\n\n", viper.ConfigFileUsed())
 


### PR DESCRIPTION
This PR allows environment variables to be used for the config. For example:

    INSTABOT_USER_INSTAGRAM_PASSWORD="my pass" go-instabot

Anything specified as an environment variable takes precedence over anything in the JSON.

Thanks   