### PR TITLE
do not use pointer of bool's

### DIFF
--- a/insta.go
+++ b/insta.go
@@ -48,7 +48,7 @@ func syncFollowers() {
 	}
 	for _, user := range users {
 		fmt.Printf("Unfollowing %s\n", user.Username)
-		if !*dev {
+		if !dev {
 			insta.UnFollow(user.ID)
 		}
 		time.Sleep(6 * time.Second)
@@ -246,7 +246,7 @@ func goThrough(images response.TagFeedsResponse) {
 func likeImage(image response.MediaItemResponse) {
 	log.Println("Liking the picture")
 	if !image.HasLiked {
-		if !*dev {
+		if !dev {
 			insta.Like(image.ID)
 		}
 		log.Println("Liked")
@@ -261,7 +261,7 @@ func likeImage(image response.MediaItemResponse) {
 func commentImage(image response.MediaItemResponse) {
 	rand.Seed(time.Now().Unix())
 	text := commentsList[rand.Intn(len(commentsList))]
-	if !*dev {
+	if !dev {
 		insta.Comment(image.ID, text)
 	}
 	log.Println("Commented " + text)
@@ -277,7 +277,7 @@ func followUser(userInfo response.GetUsernameResponse) {
 	check(err)
 	// If not following already
 	if !userFriendShip.Following {
-		if !*dev {
+		if !dev {
 			insta.Follow(user.ID)
 		}
 		log.Println("Followed")

--- a/instabot.go
+++ b/instabot.go
@@ -7,9 +7,9 @@ func main() {
 	getConfig()
 	// Tries to login
 	login()
-	if *unfollow {
+	if unfollow {
 		syncFollowers()
-	} else if *run {
+	} else if run {
 		// Loop through tags ; follows, likes, and comments, according to the config file
 		loopTags()
 	}

--- a/util.go
+++ b/util.go
@@ -13,17 +13,22 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Whether we are in development mode or not
-var dev *bool
+var (
+	// Whether we are in development mode or not
+	dev bool
 
-// Whether we want an email to be sent when the script ends / crashes
-var nomail *bool
+	// Whether we want an email to be sent when the script ends / crashes
+	nomail bool
 
-// Whether we want to launch the unfollow mode
-var unfollow *bool
+	// Whether we want to launch the unfollow mode
+	unfollow bool
 
-// Acut
-var run *bool
+	// Acut
+	run bool
+
+	// Whether we want to have logging
+	logs bool
+)
 
 // An image will be liked if the poster has more followers than likeLowerLimit, and less than likeUpperLimit
 var likeLowerLimit int
@@ -73,16 +78,16 @@ func check(err error) {
 
 // Parses the options given to the script
 func parseOptions() {
-	run = flag.Bool("run", false, "Use this option to follow, like and comment")
-	unfollow = flag.Bool("sync", false, "Use this option to unfollow those who are not following back")
-	nomail = flag.Bool("nomail", false, "Use this option to disable the email notifications")
-	dev = flag.Bool("dev", false, "Use this option to use the script in development mode : nothing will be done for real")
-	logs := flag.Bool("logs", false, "Use this option to enable the logfile")
+	flag.BoolVar(&run, "run", false, "Use this option to follow, like and comment")
+	flag.BoolVar(&unfollow, "sync", false, "Use this option to unfollow those who are not following back")
+	flag.BoolVar(&nomail, "nomail", false, "Use this option to disable the email notifications")
+	flag.BoolVar(&dev, "dev", false, "Use this option to use the script in development mode : nothing will be done for real")
+	flag.BoolVar(&logs, "logs", false, "Use this option to enable the logfile")
 
 	flag.Parse()
 
 	// -logs enables the log file
-	if *logs {
+	if logs {
 		// Opens a log file
 		t := time.Now()
 		logFile, err := os.OpenFile("instabot-"+t.Format("2006-01-02-15-04-05")+".log", os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666)
@@ -98,7 +103,7 @@ func parseOptions() {
 // Gets the conf in the config file
 func getConfig() {
 	folder := "config"
-	if *dev {
+	if dev {
 		folder = "local"
 	}
 	viper.SetConfigFile(folder + "/config.json")
@@ -139,7 +144,7 @@ func getConfig() {
 
 // Sends an email. Check out the "mail" section of the "config.json" file.
 func send(body string, success bool) {
-	if !*nomail {
+	if !nomail {
 		from := viper.GetString("user.mail.from")
 		pass := viper.GetString("user.mail.password")
 		to := viper.GetString("user.mail.to")


### PR DESCRIPTION
In Go it is uncommon to use pointer of native data types like `bool` in the case of `flag.Bool` you could use `flag.BoolVar` and pass the pointer to that call.